### PR TITLE
Fix a bug that does not cache npm packages

### DIFF
--- a/src/commands/yarn-install.yml
+++ b/src/commands/yarn-install.yml
@@ -15,6 +15,6 @@ steps:
         - << parameters.key >>-{{ arch }}
   - run: yarn install --frozen-lockfile
   - save_cache:
-      key: << parameters.key >>-{{ arch }}-{{ checksum "yarn.lock" }}
+      key: << parameters.key >>-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
       paths:
         - node_modules


### PR DESCRIPTION
Because the cache key does not include the branch name, CircleCI always displays "cache already exists" and the cache does not save.