### PR TITLE
Fix non-existent job

### DIFF
--- a/src/examples/rspec.yml
+++ b/src/examples/rspec.yml
@@ -93,7 +93,7 @@ usage:
         - js-test:
             requires:
               - js-deps
-        - rails/assets:
+        - assets:
             requires:
               - rb-deps
               - js-deps


### PR DESCRIPTION
Rails Orb does not provide an "assets" job.