### PR TITLE
Add a path that webpacker defines by default

### DIFF
--- a/src/commands/assets-precompile.yml
+++ b/src/commands/assets-precompile.yml
@@ -35,3 +35,4 @@ steps:
               - tmp/cache/webpacker
               - public/assets
               - public/packs
+              - public/packs-test


### PR DESCRIPTION
Webpacker outputs assets to `public/test-packs` in test environment.
ref: https://github.com/rails/webpacker/blob/v4.2.2/lib/install/config/webpacker.yml#L84

However, it was not cached because it was not included in the paths.