### PR TITLE
Clean assets right after precompilation

### DIFF
--- a/src/commands/assets-precompile.yml
+++ b/src/commands/assets-precompile.yml
@@ -25,7 +25,7 @@ steps:
       condition: <<parameters.restore_only>>
       steps:
         - run:
-            command: bin/rails assets:precompile
+            command: bin/rails assets:precompile assets:clean
             environment:
               RAILS_ENV: << parameters.rails_env >>
         - save_cache:


### PR DESCRIPTION
This is important to avoid filling the assets cache with old files over time. In my repo, public/packs-test grew from ~150mb to ~4gb over the course of a month causing all my CI runs to run slower over time.